### PR TITLE
Add pytest smoke test setup

### DIFF
--- a/pytest.ini
+++ b/pytest.ini
@@ -1,0 +1,2 @@
+[pytest]
+testpaths = tests

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,1 +1,2 @@
 streamlit
+pytest

--- a/tests/test_streamlit_app.py
+++ b/tests/test_streamlit_app.py
@@ -1,0 +1,9 @@
+from pathlib import Path
+
+
+def test_streamlit_app_has_title_and_copy():
+    app_path = Path(__file__).resolve().parents[1] / "streamlit_app.py"
+    contents = app_path.read_text(encoding="utf-8")
+
+    assert "st.title" in contents
+    assert "Let's start building!" in contents


### PR DESCRIPTION
### Motivation
- Provide minimal automated test coverage and a pytest configuration for the existing Streamlit starter so basic app content is verified automatically.

### Description
- Add `pytest` to `requirements.txt` to include the test runner dependency.
- Add `pytest.ini` to configure pytest discovery to the `tests` directory.
- Add `tests/test_streamlit_app.py` containing a smoke test that reads `streamlit_app.py` and asserts it contains `st.title` and the starter copy "Let's start building!".

### Testing
- Ran `python -m pytest` and the test suite passed (`1 passed`).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_696aef5832488322841804c2dd7f9c65)