### PR TITLE
Add report chunking, fix PDF parsing, and expand README with detailed setup/run instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,11 +1,20 @@
 # 🗂️ Document Organizer
 
-Upload or paste JSON/PDF/TXT content, define your categories, and generate a neatly
-organized report with a full index and details per category.
+Upload or paste JSON/PDF/TXT content, define categories, and generate a clean report with:
+- a full file index,
+- category-by-category grouped output,
+- optional snippets/full text,
+- downloadable Markdown or TXT.
 
 [![Open in Streamlit](https://static.streamlit.io/badges/streamlit_badge_black_white.svg)](https://blank-app-template.streamlit.app/)
 
-## How it works (buttons & configuration)
+## Project files (everything you need)
+- `streamlit_app.py` → the app code.
+- `requirements.txt` → Python dependencies (`streamlit`, `PyPDF2`).
+- `README.md` → setup + usage instructions.
+- `LICENSE` → license terms.
+
+## Quick product flow
 
 ```mermaid
 flowchart TD
@@ -16,48 +25,176 @@ flowchart TD
     E --> F[Preview + download report]
 ```
 
-### What each control does
+## What each UI control does
 - **Upload files / Paste content**: Add JSON, PDF, or TXT content to analyze.
 - **Define sections**: One category per line; optional keywords after a colon.
-- **Detail level**: Full text (most accurate) or snippets (shorter output).
-- **Output format**: Download as Markdown or plain text.
-- **Retry JSON parsing**: Best-effort repair for lightly malformed JSON.
-- **Analyze & organize**: Runs the categorization, index creation, and verification pass.
-- **Preview**: See the generated report before downloading.
+- **Detail level**: Full text (most complete) or snippets (shorter output).
+- **Output format**: Download as Markdown (`.md`) or plain text (`.txt`).
+- **Retry JSON parsing**: Attempts light cleanup for malformed JSON.
+- **Analyze & organize**: Runs extraction, keyword matching, grouping, and output generation.
+- **Preview**: Shows generated report before download.
 
-## Get the project (download first)
+---
 
-You must have the project folder on your computer before running anything.
+## Exactly what to install
+You only need:
+1. **Python 3.10+**
+2. **Git** (only if cloning; not needed if using ZIP)
 
-### Option A: GitHub (recommended)
-Run these **in your terminal/command line**:
+You do **not** install Streamlit/PyPDF2 manually one-by-one; `pip install -r requirements.txt` installs both.
 
+---
+
+## Run locally (outside Codex/ChatGPT) — exact commands
+
+## Option A: macOS / Linux (copy-paste exactly)
+
+### Step 1) Check Python and pip
+```bash
+python3 --version
+pip3 --version
 ```
-git clone <PASTE_GITHUB_REPO_URL>
-cd <REPO_FOLDER_NAME>
+
+### Step 2) Get the code
+Replace with your actual repo URL:
+```bash
+git clone https://github.com/<your-user>/<your-repo>.git
+cd <your-repo>
 ```
 
-### Option B: ZIP download
-1. Download the ZIP from GitHub (or wherever you received it).
-2. Unzip it.
-3. Open terminal and go to the unzipped folder:
-
-```
+If you downloaded ZIP instead, unzip and then:
+```bash
 cd /path/to/unzipped-folder
 ```
 
-## Run the app
+### Step 3) Create + activate virtual environment
+```bash
+python3 -m venv .venv
+source .venv/bin/activate
+```
 
-Run these commands **in your terminal/command line**:
+### Step 4) Install dependencies
+```bash
+pip install -r requirements.txt
+```
 
-1. Install the requirements
+### Step 5) Run app
+```bash
+streamlit run streamlit_app.py
+```
 
-   ```
-   $ pip install -r requirements.txt
-   ```
+### Step 6) Open in browser
+Open:
+```text
+http://localhost:8501
+```
 
-2. Run the app
+### Step 7) Stop app
+In terminal:
+```text
+Ctrl + C
+```
 
-   ```
-   $ streamlit run streamlit_app.py
-   ```
+---
+
+## Option B: Windows PowerShell (copy-paste exactly)
+
+### Step 1) Check Python and pip
+```powershell
+python --version
+pip --version
+```
+
+### Step 2) Get the code
+Replace with your actual repo URL:
+```powershell
+git clone https://github.com/<your-user>/<your-repo>.git
+cd <your-repo>
+```
+
+If you downloaded ZIP instead, unzip and then:
+```powershell
+cd C:\path\to\unzipped-folder
+```
+
+### Step 3) Create + activate virtual environment
+```powershell
+python -m venv .venv
+.\.venv\Scripts\Activate.ps1
+```
+
+### Step 4) Install dependencies
+```powershell
+pip install -r requirements.txt
+```
+
+### Step 5) Run app
+```powershell
+streamlit run streamlit_app.py
+```
+
+### Step 6) Open in browser
+Open:
+```text
+http://localhost:8501
+```
+
+### Step 7) Stop app
+In terminal:
+```text
+Ctrl + C
+```
+
+---
+
+## Common issues (fast fixes)
+
+### `streamlit: command not found`
+Use:
+```bash
+python -m streamlit run streamlit_app.py
+```
+
+### `pip` installs globally by mistake
+Make sure virtualenv is active first:
+- macOS/Linux prompt should usually show `(.venv)`
+- Windows PowerShell prompt should usually show `(.venv)`
+
+### Large upload fails
+Streamlit default upload limit is ~200MB. Increase via config:
+
+```toml
+# ~/.streamlit/config.toml (macOS/Linux)
+# %USERPROFILE%\.streamlit\config.toml (Windows)
+[server]
+maxUploadSize = 700
+```
+
+### PDF parsing errors
+This app uses `PyPDF2`; image-only/scanned PDFs may not contain extractable text.
+
+---
+
+## Commands used to verify this repo
+```bash
+python3 -m compileall streamlit_app.py
+python3 - <<'PY'
+import io
+from PyPDF2 import PdfWriter
+import streamlit_app as app
+
+writer = PdfWriter()
+writer.add_blank_page(width=72, height=72)
+buf = io.BytesIO()
+writer.write(buf)
+text, err = app.extract_text_from_pdf(buf.getvalue())
+assert err is None, err
+assert isinstance(text, str)
+
+rules = app.parse_section_rules('Finance: budget,invoice\nEngineering: api,backend')
+assert len(rules) == 2
+matched = app.match_keywords('The backend api budget was approved', rules[1])
+assert 'api' in [m.lower() for m in matched]
+print('smoke tests passed')
+PY
+```

--- a/streamlit_app.py
+++ b/streamlit_app.py
@@ -1,5 +1,7 @@
+import io
 import json
 import textwrap
+import zipfile
 from dataclasses import dataclass
 from typing import Dict, Iterable, List, Optional, Tuple
 
@@ -55,7 +57,7 @@ def extract_text_from_pdf(file_bytes: bytes) -> Tuple[str, Optional[str]]:
     if PdfReader is None:
         return "", "PDF support requires PyPDF2. Add it to requirements to enable parsing."
     try:
-        reader = PdfReader(file_bytes)
+        reader = PdfReader(io.BytesIO(file_bytes))
         pages = [page.extract_text() or "" for page in reader.pages]
         text = "\n".join(pages).strip()
         return text, None
@@ -126,6 +128,48 @@ def extract_snippets(text: str, keywords: Iterable[str], window: int = 180) -> L
     return snippets
 
 
+def chunk_text(text: str, chunk_size: int) -> List[str]:
+    if chunk_size <= 0:
+        return [text]
+    lines = text.splitlines(keepends=True)
+    chunks: List[str] = []
+    current = ""
+    for line in lines:
+        if len(current) + len(line) <= chunk_size:
+            current += line
+            continue
+        if current:
+            chunks.append(current)
+            current = ""
+        if len(line) <= chunk_size:
+            current = line
+            continue
+        for idx in range(0, len(line), chunk_size):
+            piece = line[idx : idx + chunk_size]
+            if len(piece) == chunk_size:
+                chunks.append(piece)
+            else:
+                current = piece
+    if current:
+        chunks.append(current)
+    return chunks or [text]
+
+
+def build_chunks_zip(
+    chunks: List[str],
+    base_name: str,
+    user_name: str,
+    extension: str,
+) -> bytes:
+    buffer = io.BytesIO()
+    with zipfile.ZipFile(buffer, mode="w", compression=zipfile.ZIP_DEFLATED) as zip_file:
+        for index, chunk in enumerate(chunks, start=1):
+            chunk_name = f"{base_name}_{user_name}_chunk_{index:03d}.{extension}"
+            zip_file.writestr(chunk_name, chunk)
+    buffer.seek(0)
+    return buffer.getvalue()
+
+
 with st.sidebar:
     st.header("1) Add content")
     uploaded_files = st.file_uploader(
@@ -161,6 +205,19 @@ with st.sidebar:
         "Retry JSON parsing on error (best effort)",
         value=True,
         help="Attempts a light cleanup if JSON parsing fails.",
+    )
+    create_chunks = st.checkbox(
+        "Also create smaller chunk files",
+        value=False,
+        help="Splits the generated report into smaller parts and provides individual and ZIP downloads.",
+    )
+    chunk_size = st.slider(
+        "Chunk size (characters)",
+        min_value=1000,
+        max_value=50000,
+        value=8000,
+        step=500,
+        disabled=not create_chunks,
     )
     run_button = st.button("Analyze & organize")
 
@@ -306,6 +363,28 @@ if run_button and (uploaded_files or pasted_text.strip()):
         file_name=output_name,
         mime="text/markdown" if extension == "md" else "text/plain",
     )
+
+    if create_chunks:
+        report_chunks = chunk_text(report_text, chunk_size)
+        zip_bytes = build_chunks_zip(report_chunks, base_name, user_name, extension)
+        st.subheader("Chunked downloads")
+        st.caption(f"Created {len(report_chunks)} chunk(s) at ~{chunk_size} chars each.")
+
+        st.download_button(
+            "Download all chunks (ZIP)",
+            data=zip_bytes,
+            file_name=f"{base_name}_{user_name}_chunks.zip",
+            mime="application/zip",
+        )
+
+        for index, chunk in enumerate(report_chunks, start=1):
+            st.download_button(
+                f"Download chunk {index}",
+                data=chunk,
+                file_name=f"{base_name}_{user_name}_chunk_{index:03d}.{extension}",
+                mime="text/markdown" if extension == "md" else "text/plain",
+            )
+
     st.subheader("Preview")
     st.text_area(
         "Generated report preview",


### PR DESCRIPTION
### Motivation
- Provide smaller, downloadable pieces of large generated reports and improve user onboarding with clearer setup and run instructions.
- Make PDF parsing more robust when receiving raw bytes and surface helpful troubleshooting guidance for common issues.

### Description
- Added chunking support including a `create_chunks` checkbox, `chunk_size` slider, `chunk_text` function, `build_chunks_zip` function, and per-chunk + ZIP download buttons to `streamlit_app.py`.
- Fixed PDF reading by wrapping bytes in `io.BytesIO` when constructing `PdfReader`, and added the `zipfile` import used for packaging chunks.
- Expanded `README.md` with a full "Project files" summary, exact macOS/Linux and Windows run commands, troubleshooting tips, and a small verification script that compiles the app and runs smoke checks.

### Testing
- Ran `python3 -m compileall streamlit_app.py` which completed without errors.
- Executed the smoke script included in the README that creates a test PDF and verifies `extract_text_from_pdf`, `parse_section_rules`, and keyword matching, which printed `smoke tests passed` indicating success.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69833521eca48322b4f85f054b75d78e)